### PR TITLE
fix: 修复 Demo CSV 表头空格崩溃问题

### DIFF
--- a/src/quant_balance/demo.py
+++ b/src/quant_balance/demo.py
@@ -180,11 +180,12 @@ def load_demo_bars(request: BacktestDemoRequest) -> list[MarketBar]:
 
 
 def parse_csv_text_to_bars(*, csv_text: str, symbol: str) -> list[MarketBar]:
-    reader = csv.DictReader(io.StringIO(csv_text.strip()))
+    reader = csv.DictReader(io.StringIO(csv_text.strip()), skipinitialspace=True)
     if reader.fieldnames is None:
         raise DemoValidationError("CSV 为空，或缺少表头。")
 
-    fieldnames = {name.strip() for name in reader.fieldnames}
+    reader.fieldnames = [name.strip() for name in reader.fieldnames]
+    fieldnames = set(reader.fieldnames)
     missing_columns = [column for column in REQUIRED_CSV_COLUMNS if column not in fieldnames]
     if missing_columns:
         raise DemoValidationError(
@@ -193,7 +194,8 @@ def parse_csv_text_to_bars(*, csv_text: str, symbol: str) -> list[MarketBar]:
 
     bars: list[MarketBar] = []
     try:
-        for row in reader:
+        for raw_row in reader:
+            row = {(key or "").strip(): value for key, value in raw_row.items()}
             bars.append(
                 MarketBar(
                     symbol=symbol,
@@ -205,7 +207,7 @@ def parse_csv_text_to_bars(*, csv_text: str, symbol: str) -> list[MarketBar]:
                     volume=float(row["volume"]),
                 )
             )
-    except ValueError as exc:
+    except (KeyError, ValueError) as exc:
         raise DemoValidationError(
             "CSV 中存在无法识别的数值或日期格式。请使用 YYYY-MM-DD 日期，并确保价格/成交量列都是数字。"
         ) from exc

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -53,6 +53,17 @@ def test_parse_csv_text_to_bars_rejects_invalid_value_format() -> None:
         parse_csv_text_to_bars(csv_text=csv_text, symbol="600519.SH")
 
 
+def test_parse_csv_text_to_bars_accepts_headers_with_spaces() -> None:
+    csv_text = "date, open,high, low,close, volume\n2026-01-05,10,11,9,10.5,1000"
+
+    bars = parse_csv_text_to_bars(csv_text=csv_text, symbol="600519.SH")
+
+    assert len(bars) == 1
+    assert bars[0].date == date(2026, 1, 5)
+    assert bars[0].open == 10.0
+    assert bars[0].volume == 1000.0
+
+
 def test_load_demo_bars_supports_example_mode() -> None:
     bars = load_demo_bars(BacktestDemoRequest(input_mode="example", symbol="600519.SH"))
 


### PR DESCRIPTION
## 本次修复
- 修复 Demo CSV 表头在逗号后带空格时，`parse_csv_text_to_bars` 会因 `KeyError` 直接崩溃的问题
- 在 `csv.DictReader` 中启用 `skipinitialspace=True`
- 统一规范化 `reader.fieldnames` 与逐行读取后的字段 key，兼容 `date, open,high, low,close, volume` 这类常见输入
- 保持错误出口为用户可理解的 `DemoValidationError`

## 测试
使用项目本地 `.venv` 运行：
- `pytest -q tests/test_demo.py` → `11 passed`
- `pytest -q` → `38 passed`

## 关联 issue
- closes #10
