### PR TITLE
test: 补齐安装后 CLI smoke 回归测试

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ authors = [
 ]
 dependencies = []
 
+[project.scripts]
+quant-balance = "quant_balance.main:main"
+
 [tool.setuptools]
 package-dir = {"" = "src"}
 

--- a/tests/test_smoke_cli.py
+++ b/tests/test_smoke_cli.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EXPECTED_OUTPUT = "QuantBalance is ready."
+
+
+def test_package_install_exposes_console_entrypoint(tmp_path: Path) -> None:
+    venv_dir = tmp_path / "venv"
+    subprocess.run([sys.executable, "-m", "venv", str(venv_dir)], check=True, cwd=ROOT)
+
+    if sys.platform == "win32":
+        python_bin = venv_dir / "Scripts" / "python.exe"
+        cli_bin = venv_dir / "Scripts" / "quant-balance.exe"
+    else:
+        python_bin = venv_dir / "bin" / "python"
+        cli_bin = venv_dir / "bin" / "quant-balance"
+
+    subprocess.run(
+        [str(python_bin), "-m", "pip", "install", "-e", str(ROOT)],
+        check=True,
+        cwd=ROOT,
+    )
+
+    result = subprocess.run(
+        [str(cli_bin)],
+        check=True,
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout.strip() == EXPECTED_OUTPUT
+
+
+def test_module_entrypoint_runs_after_install(tmp_path: Path) -> None:
+    venv_dir = tmp_path / "venv-module"
+    subprocess.run([sys.executable, "-m", "venv", str(venv_dir)], check=True, cwd=ROOT)
+
+    if sys.platform == "win32":
+        python_bin = venv_dir / "Scripts" / "python.exe"
+    else:
+        python_bin = venv_dir / "bin" / "python"
+
+    subprocess.run(
+        [str(python_bin), "-m", "pip", "install", "-e", str(ROOT)],
+        check=True,
+        cwd=ROOT,
+    )
+
+    result = subprocess.run(
+        [str(python_bin), "-m", "quant_balance.main"],
+        check=True,
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout.strip() == EXPECTED_OUTPUT


### PR DESCRIPTION
## Summary
- 为 QuantBalance 增加 `quant-balance` 控制台入口，确保安装后有稳定的公开入口可测
- 新增隔离 venv 的 smoke test，覆盖 `pip install -e .` 后的 console script 与 `python -m quant_balance.main`
- 继续复用现有 pytest CI，让安装后的用户入口跟随测试矩阵回归

## Testing
- `python -m pytest -q`

Fixes #14
