### PR TITLE
fix: 为 Demo CSV 增加时间序列与价格区间有效性校验

### DIFF
--- a/src/quant_balance/demo.py
+++ b/src/quant_balance/demo.py
@@ -193,20 +193,41 @@ def parse_csv_text_to_bars(*, csv_text: str, symbol: str) -> list[MarketBar]:
         )
 
     bars: list[MarketBar] = []
+    previous_date: date | None = None
+    seen_dates: set[date] = set()
     try:
         for raw_row in reader:
             row = {(key or "").strip(): value for key, value in raw_row.items()}
-            bars.append(
-                MarketBar(
-                    symbol=symbol,
-                    date=date.fromisoformat((row["date"] or "").strip()),
-                    open=float(row["open"]),
-                    high=float(row["high"]),
-                    low=float(row["low"]),
-                    close=float(row["close"]),
-                    volume=float(row["volume"]),
-                )
+            bar = MarketBar(
+                symbol=symbol,
+                date=date.fromisoformat((row["date"] or "").strip()),
+                open=float(row["open"]),
+                high=float(row["high"]),
+                low=float(row["low"]),
+                close=float(row["close"]),
+                volume=float(row["volume"]),
             )
+
+            if previous_date and bar.date < previous_date:
+                raise DemoValidationError("CSV 日期顺序不正确：请按交易日从早到晚排列，不要乱序。")
+            if bar.date in seen_dates:
+                raise DemoValidationError("CSV 存在重复交易日：同一个日期只能出现一行数据。")
+            if min(bar.open, bar.high, bar.low, bar.close) <= 0:
+                raise DemoValidationError("CSV 价格必须全部大于 0，请检查 open/high/low/close 列。")
+            if bar.volume < 0:
+                raise DemoValidationError("CSV 成交量不能为负数，请检查 volume 列。")
+            if bar.high < bar.low:
+                raise DemoValidationError("CSV 价格区间不合法：high 不能小于 low。")
+            if not (bar.low <= bar.open <= bar.high):
+                raise DemoValidationError("CSV 价格区间不合法：open 必须落在 low 和 high 之间。")
+            if not (bar.low <= bar.close <= bar.high):
+                raise DemoValidationError("CSV 价格区间不合法：close 必须落在 low 和 high 之间。")
+
+            bars.append(bar)
+            previous_date = bar.date
+            seen_dates.add(bar.date)
+    except DemoValidationError:
+        raise
     except (KeyError, ValueError) as exc:
         raise DemoValidationError(
             "CSV 中存在无法识别的数值或日期格式。请使用 YYYY-MM-DD 日期，并确保价格/成交量列都是数字。"

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -119,3 +119,56 @@ def test_build_demo_result_context_exposes_summary_trades_and_assumptions() -> N
     assert context.summary["max_drawdown_end"] == "2026-01-07"
     assert context.closed_trades == []
     assert any("滑点" in note for note in context.assumptions)
+
+
+def test_parse_csv_text_to_bars_rejects_unsorted_dates() -> None:
+    csv_text = """date,open,high,low,close,volume
+2026-01-06,10,11,9,10.5,1000
+2026-01-05,10,11,9,10.5,1000"""
+
+    with pytest.raises(DemoValidationError, match="日期顺序不正确"):
+        parse_csv_text_to_bars(csv_text=csv_text, symbol="600519.SH")
+
+
+def test_parse_csv_text_to_bars_rejects_duplicate_dates() -> None:
+    csv_text = """date,open,high,low,close,volume
+2026-01-05,10,11,9,10.5,1000
+2026-01-05,10.2,11.1,9.1,10.6,1100"""
+
+    with pytest.raises(DemoValidationError, match="重复交易日"):
+        parse_csv_text_to_bars(csv_text=csv_text, symbol="600519.SH")
+
+
+def test_parse_csv_text_to_bars_rejects_non_positive_prices() -> None:
+    csv_text = "date,open,high,low,close,volume\n2026-01-05,0,11,9,10.5,1000"
+
+    with pytest.raises(DemoValidationError, match="价格必须全部大于 0"):
+        parse_csv_text_to_bars(csv_text=csv_text, symbol="600519.SH")
+
+
+def test_parse_csv_text_to_bars_rejects_negative_volume() -> None:
+    csv_text = "date,open,high,low,close,volume\n2026-01-05,10,11,9,10.5,-1"
+
+    with pytest.raises(DemoValidationError, match="成交量不能为负数"):
+        parse_csv_text_to_bars(csv_text=csv_text, symbol="600519.SH")
+
+
+def test_parse_csv_text_to_bars_rejects_high_below_low() -> None:
+    csv_text = "date,open,high,low,close,volume\n2026-01-05,10,8,9,9.5,1000"
+
+    with pytest.raises(DemoValidationError, match="high 不能小于 low"):
+        parse_csv_text_to_bars(csv_text=csv_text, symbol="600519.SH")
+
+
+def test_parse_csv_text_to_bars_rejects_open_outside_price_range() -> None:
+    csv_text = "date,open,high,low,close,volume\n2026-01-05,12,11,9,10.5,1000"
+
+    with pytest.raises(DemoValidationError, match="open 必须落在 low 和 high 之间"):
+        parse_csv_text_to_bars(csv_text=csv_text, symbol="600519.SH")
+
+
+def test_parse_csv_text_to_bars_rejects_close_outside_price_range() -> None:
+    csv_text = "date,open,high,low,close,volume\n2026-01-05,10,11,9,12,1000"
+
+    with pytest.raises(DemoValidationError, match="close 必须落在 low 和 high 之间"):
+        parse_csv_text_to_bars(csv_text=csv_text, symbol="600519.SH")


### PR DESCRIPTION
## Summary
- 在 demo CSV 解析阶段增加时间序列与价格区间有效性校验
- 对乱序日期、重复交易日、非正价格、负成交量和非法 OHLC 区间给出明确中文提示
- 补充对应测试覆盖关键异常路径

## Testing
- .venv/bin/python -m pytest -q tests/test_demo.py
- .venv/bin/python -m pytest -q

Fixes zionwudt/quant-balance#20