### PR TITLE
chore: 补齐测试依赖声明与本地测试说明

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install package and test dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e . pytest
+          python -m pip install -e .[dev]
 
       - name: Run test suite
         run: pytest -q

--- a/README.md
+++ b/README.md
@@ -149,6 +149,22 @@ quant-balance demo --json
 
 The built-in demo uses `examples/demo_backtest.csv` and prints a compact summary including final equity, total return, max drawdown, and trades count.
 
+## Local Testing
+
+Install the package together with development/test dependencies:
+
+```bash
+python -m pip install -e .[dev]
+```
+
+Then run the test suite:
+
+```bash
+pytest -q
+```
+
+This keeps runtime dependencies minimal while giving contributors and CI a single, explicit way to prepare the local test environment.
+
 ## Local Demo Input Foundation
 
 To make a future local Web demo more product-friendly, the repository now includes a demo input/validation foundation in `quant_balance.demo`:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,11 @@ authors = [
 ]
 dependencies = []
 
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.0",
+]
+
 [project.scripts]
 quant-balance = "quant_balance.main:main"
 


### PR DESCRIPTION
$## Summary\n\n为项目补齐最小可用的测试依赖声明，并把本地运行测试的安装/执行方式写进 README，同时让 CI 与文档使用同一套依赖入口。\n\n## Changes\n\n- 在 `pyproject.toml` 中新增 `project.optional-dependencies.dev`，声明 `pytest>=8.0`\n- 在 `README.md` 中新增 Local Testing 说明，明确 `pip install -e .[dev]` 与 `pytest -q`\n- 调整 GitHub Actions 测试工作流，改为通过 `pip install -e .[dev]` 安装测试依赖\n\n## Testing\n\n- 在全新虚拟环境中执行 `python -m pip install -e .[dev]`\n- 执行 `pytest -q`，结果 `43 passed`\n\nFixes zionwudt/quant-balance#17