### PR TITLE
fix: 精简 demo 帮助信息层级

### DIFF
--- a/src/quant_balance/cli.py
+++ b/src/quant_balance/cli.py
@@ -19,7 +19,6 @@ def build_parser() -> argparse.ArgumentParser:
     subparsers = parser.add_subparsers(dest="command")
 
     demo_parser = subparsers.add_parser("demo", help="run the built-in backtest demo")
-    demo_parser.add_argument("action", nargs="?", default="run", choices=["run"], help="demo action to execute")
     demo_parser.add_argument("--csv", default=str(DEFAULT_EXAMPLE_PATH), help="path to demo CSV file")
     demo_parser.add_argument("--symbol", default=DEFAULT_SYMBOL, help="symbol to use for the demo bars")
     demo_parser.add_argument("--initial-cash", type=float, default=100_000.0, help="initial cash for the backtest")

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_demo_help_does_not_expose_redundant_action_layer() -> None:
+    root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [sys.executable, "-m", "quant_balance.main", "demo", "--help"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(root / 'src')},
+    )
+
+    help_text = result.stdout
+
+    assert "{run}" not in help_text
+    assert "demo action to execute" not in help_text
+    assert "--csv" in help_text
+    assert "--symbol" in help_text
+    assert "--initial-cash" in help_text


### PR DESCRIPTION
## Summary

去掉 `quant-balance demo` 当前没有实际价值的 action 位置参数，让 help 输出直接聚焦真正可用的参数，减少首次使用歧义。

## Changes

- 删除 `demo` 子命令下仅有单一取值的 `action={run}` 位置参数
- 保持 `quant-balance demo` 与 README quickstart 用法一致
- 新增 help 输出回归测试，防止后续再次暴露多余层级

## Testing

- `PYTHONPATH=src pytest -q`（51 passed）
- 覆盖 `python -m quant_balance.main demo --help` 输出断言

Fixes zionwudt/quant-balance#18