### PR TITLE
chore: 补齐 Python 构建产物忽略规则

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ venv/
 .mypy_cache/
 .coverage
 htmlcov/
+*.egg-info/
+.eggs/
+build/
+dist/
 
 # IDE
 .vscode/

--- a/tests/test_gitignore.py
+++ b/tests/test_gitignore.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REQUIRED_IGNORE_RULES = [
+    "*.egg-info/",
+    ".eggs/",
+    "build/",
+    "dist/",
+]
+
+
+def test_gitignore_covers_python_build_outputs() -> None:
+    root = Path(__file__).resolve().parents[1]
+    gitignore = (root / ".gitignore").read_text(encoding="utf-8")
+
+    for rule in REQUIRED_IGNORE_RULES:
+        assert rule in gitignore


### PR DESCRIPTION
## Summary

补齐 QuantBalance 对常见 Python 构建/发布产物的忽略规则，避免本地安装或打包后工作区被 `egg-info`、`build`、`dist` 等非源码文件污染。

## Changes

- 在 `.gitignore` 中补充 `*.egg-info/`、`.eggs/`、`build/`、`dist/`
- 新增回归测试，确保这些关键忽略规则后续不会被删掉

## Testing

- `PYTHONPATH=src pytest -q`（此前全量 51 passed）
- `python -m pytest -q tests/test_gitignore.py`（1 passed）
- 本地 `python -m build` 验证会生成 `build/`、`dist/`，且命中忽略规则，不会形成额外误提交风险

Fixes zionwudt/quant-balance#19