### PR TITLE
fix: 精简 web-demo 帮助信息层级

### DIFF
--- a/src/quant_balance/cli.py
+++ b/src/quant_balance/cli.py
@@ -28,7 +28,6 @@ def build_parser() -> argparse.ArgumentParser:
     demo_parser.add_argument("--json", action="store_true", help="print the full report as JSON")
 
     web_demo_parser = subparsers.add_parser("web-demo", help="run the local web demo shell")
-    web_demo_parser.add_argument("action", nargs="?", default="serve", choices=["serve"], help="web demo action to execute")
     web_demo_parser.add_argument("--host", default=DEFAULT_HOST, help="host to bind the local web demo")
     web_demo_parser.add_argument("--port", type=int, default=DEFAULT_PORT, help="port to bind the local web demo")
     web_demo_parser.add_argument("--developer-mode", action="store_true", help="enable local path mode for developers")

--- a/tests/test_web_demo_help.py
+++ b/tests/test_web_demo_help.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_web_demo_help_does_not_expose_redundant_action_layer() -> None:
+    root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [sys.executable, "-m", "quant_balance.main", "web-demo", "--help"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(root / 'src')},
+    )
+
+    help_text = result.stdout
+
+    assert "{serve}" not in help_text
+    assert "web demo action to execute" not in help_text
+    assert "--host" in help_text
+    assert "--port" in help_text
+    assert "--developer-mode" in help_text


### PR DESCRIPTION
## Summary

去掉 `quant-balance web-demo` 当前没有实际价值的 `{serve}` 位置参数，让帮助信息与 `demo` 子命令保持一致，聚焦真正可调的参数。

## Changes

- 删除 `web-demo` 子命令下仅有单一取值的 `action={serve}` 位置参数
- 保持 README 中 `quant-balance web-demo --host ... --port ...` 的标准用法不变
- 新增 `web-demo --help` 回归测试，防止后续再次回归出多余层级

## Testing

- `PYTHONPATH=src pytest -q`（59 passed）
- 覆盖 `python -m quant_balance.main web-demo --help` 输出断言

Fixes zionwudt/quant-balance#31