### PR TITLE
fix: 提升 CLI 根命令可发现性

### DIFF
--- a/src/quant_balance/cli.py
+++ b/src/quant_balance/cli.py
@@ -13,6 +13,7 @@ from quant_balance.web_demo import DEFAULT_HOST, DEFAULT_PORT, run_demo_web_serv
 
 DEFAULT_SYMBOL = "600519.SH"
 DEFAULT_EXAMPLE_PATH = Path(__file__).resolve().parents[2] / "examples" / "demo_backtest.csv"
+ROOT_COMMAND_HINT = "Use 'quant-balance --help' to explore commands, or try 'quant-balance demo' and 'quant-balance web-demo'."
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -65,6 +66,7 @@ def run_cli(argv: list[str] | None = None) -> int:
         return 0
 
     print("QuantBalance is ready.")
+    print(ROOT_COMMAND_HINT)
     return 0
 
 

--- a/tests/test_root_cli.py
+++ b/tests/test_root_cli.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from quant_balance.cli import ROOT_COMMAND_HINT
+
+
+def test_root_command_prints_discoverable_next_steps() -> None:
+    root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [sys.executable, "-m", "quant_balance.main"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(root / 'src')},
+    )
+
+    lines = result.stdout.strip().splitlines()
+
+    assert lines[0] == "QuantBalance is ready."
+    assert ROOT_COMMAND_HINT in result.stdout
+    assert "--help" in result.stdout
+    assert "demo" in result.stdout
+    assert "web-demo" in result.stdout

--- a/tests/test_smoke_cli.py
+++ b/tests/test_smoke_cli.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-EXPECTED_OUTPUT = "QuantBalance is ready."
+EXPECTED_OUTPUT = "QuantBalance is ready.\nUse 'quant-balance --help' to explore commands, or try 'quant-balance demo' and 'quant-balance web-demo'."
 
 
 def test_package_install_exposes_console_entrypoint(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

让 `quant-balance` 根命令在首次执行时给出明确的下一步指引，而不是只输出一句占位文案就退出。

## Changes

- 为 CLI 根命令增加 discoverability 提示
- 明确引导用户使用 `quant-balance --help`
- 同时给出可直接尝试的 `quant-balance demo` 与 `quant-balance web-demo`
- 新增根命令输出回归测试，并同步更新安装后 smoke 断言

## Testing

- `PYTHONPATH=src pytest -q`（59 passed）
- 覆盖模块入口与安装后 console entrypoint 的根命令输出

Fixes zionwudt/quant-balance#29