### PR TITLE
fix: 降级短样本 demo 的年化类指标

### DIFF
--- a/src/quant_balance/cli.py
+++ b/src/quant_balance/cli.py
@@ -98,14 +98,20 @@ def format_demo_summary(report: BacktestReport, *, csv_path: Path, symbol: str, 
         f"Data: {csv_path}",
         f"Symbol: {symbol}",
         f"Strategy: MA cross ({short_window}/{long_window})",
-        "",
-        "Summary",
-        f"- Final equity: {report.final_equity:.2f}",
-        f"- Total return: {report.total_return_pct:.2f}%",
-        f"- Max drawdown: {report.max_drawdown_pct:.2f}%",
-        f"- Trades: {report.trades_count}",
-        f"- Win rate: {report.win_rate_pct:.2f}%",
     ]
+    if report.sample_size_warning:
+        lines.extend(["", f"Note: {report.sample_size_warning}"])
+    lines.extend(
+        [
+            "",
+            "Summary",
+            f"- Final equity: {report.final_equity:.2f}",
+            f"- Total return: {report.total_return_pct:.2f}%",
+            f"- Max drawdown: {report.max_drawdown_pct:.2f}%",
+            f"- Trades: {report.trades_count}",
+            f"- Win rate: {report.win_rate_pct:.2f}%",
+        ]
+    )
     if report.max_drawdown_start and report.max_drawdown_end:
         lines.append(f"- Drawdown window: {report.max_drawdown_start.isoformat()} -> {report.max_drawdown_end.isoformat()}")
     return "\n".join(lines)

--- a/src/quant_balance/report.py
+++ b/src/quant_balance/report.py
@@ -9,6 +9,8 @@ import math
 from quant_balance.models import Fill
 
 TRADING_DAYS_PER_YEAR = 252
+MIN_PERIODS_FOR_ANNUALIZED_METRICS = 60
+SHORT_SAMPLE_WARNING = "当前样本较短，年化收益、波动率、夏普与 Sortino 仅供演示参考。"
 
 
 @dataclass(slots=True)
@@ -29,10 +31,10 @@ class BacktestReport:
     initial_equity: float
     final_equity: float
     total_return_pct: float
-    annualized_return_pct: float
-    annualized_volatility_pct: float
-    sharpe_ratio: float
-    sortino_ratio: float
+    annualized_return_pct: float | None
+    annualized_volatility_pct: float | None
+    sharpe_ratio: float | None
+    sortino_ratio: float | None
     max_drawdown_pct: float
     max_drawdown_amount: float
     max_drawdown_start: date | None
@@ -46,6 +48,7 @@ class BacktestReport:
     benchmark_name: str | None = None
     benchmark_return_pct: float | None = None
     excess_return_pct: float | None = None
+    sample_size_warning: str | None = None
     closed_trades: list[ClosedTrade] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, object]:
@@ -78,10 +81,18 @@ def generate_report(
     final_equity = equity_curve[-1] if equity_curve else initial_equity
     total_return_pct = _safe_pct_change(initial_equity, final_equity)
     daily_returns = _daily_returns(equity_curve)
-    annualized_return_pct = _annualized_return_pct(initial_equity, final_equity, len(equity_curve))
-    annualized_volatility_pct = _annualized_volatility_pct(daily_returns)
-    sharpe_ratio = _sharpe_ratio(daily_returns)
-    sortino_ratio = _sortino_ratio(daily_returns)
+    sample_size_warning = None
+    if len(equity_curve) < MIN_PERIODS_FOR_ANNUALIZED_METRICS:
+        annualized_return_pct = None
+        annualized_volatility_pct = None
+        sharpe_ratio = None
+        sortino_ratio = None
+        sample_size_warning = SHORT_SAMPLE_WARNING
+    else:
+        annualized_return_pct = _annualized_return_pct(initial_equity, final_equity, len(equity_curve))
+        annualized_volatility_pct = _annualized_volatility_pct(daily_returns)
+        sharpe_ratio = _sharpe_ratio(daily_returns)
+        sortino_ratio = _sortino_ratio(daily_returns)
     drawdown_amount, drawdown_pct, drawdown_start, drawdown_end = _max_drawdown(equity_curve, equity_dates)
     closed_trades = _closed_trades(fills)
     trades_count = len(closed_trades)
@@ -118,6 +129,7 @@ def generate_report(
         benchmark_name=benchmark_name,
         benchmark_return_pct=benchmark_return_pct,
         excess_return_pct=excess_return_pct,
+        sample_size_warning=sample_size_warning,
         closed_trades=closed_trades,
     )
 

--- a/tests/test_cli_demo.py
+++ b/tests/test_cli_demo.py
@@ -56,3 +56,4 @@ def test_module_demo_command_supports_json_output() -> None:
     assert payload["final_equity"] > 0
     assert payload["trades_count"] >= 1
     assert payload["max_drawdown_start"] is not None
+    assert payload["sample_size_warning"] is not None

--- a/tests/test_short_sample_metrics.py
+++ b/tests/test_short_sample_metrics.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+from quant_balance.report import SHORT_SAMPLE_WARNING, generate_report
+
+
+def test_generate_report_degrades_annualized_metrics_for_short_samples() -> None:
+    report = generate_report(
+        initial_equity=100.0,
+        equity_curve=[100.0, 101.0, 99.5, 100.5],
+        equity_dates=[date(2026, 1, 1) + timedelta(days=i) for i in range(4)],
+        fills=[],
+    )
+
+    assert report.sample_size_warning == SHORT_SAMPLE_WARNING
+    assert report.annualized_return_pct is None
+    assert report.annualized_volatility_pct is None
+    assert report.sharpe_ratio is None
+    assert report.sortino_ratio is None
+
+
+def test_demo_json_output_marks_short_sample_metrics_as_null_and_warns() -> None:
+    root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [sys.executable, "-m", "quant_balance.main", "demo", "--json"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(root / 'src')},
+    )
+
+    payload = json.loads(result.stdout)
+
+    assert payload["sample_size_warning"] == SHORT_SAMPLE_WARNING
+    assert payload["annualized_return_pct"] is None
+    assert payload["annualized_volatility_pct"] is None
+    assert payload["sharpe_ratio"] is None
+    assert payload["sortino_ratio"] is None
+
+
+def test_demo_text_summary_shows_short_sample_note() -> None:
+    root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [sys.executable, "-m", "quant_balance.main", "demo"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(root / 'src')},
+    )
+
+    assert SHORT_SAMPLE_WARNING in result.stdout


### PR DESCRIPTION
## Summary

为短样本 demo 增加稳定的提示与降级规则，避免年化收益、波动率、夏普、Sortino 在极短样本里被用户误当成有分析意义的稳定结论。

## Changes

- 当样本长度不足阈值时，为结果增加 `sample_size_warning`
- 将 `annualized_return_pct`、`annualized_volatility_pct`、`sharpe_ratio`、`sortino_ratio` 降级为 `null`
- 在文本版 demo summary 中补充短样本提示文案
- 增加 JSON / 文本输出与报告层的回归测试

## Testing

- `PYTHONPATH=src pytest -q`（61 passed）
- 覆盖短样本 report、`demo --json` 与文本 summary 的稳定行为

Fixes zionwudt/quant-balance#30