### PR TITLE
fix: 在 Web Demo 结果页展示短样本提示

### DIFF
--- a/src/quant_balance/demo.py
+++ b/src/quant_balance/demo.py
@@ -72,6 +72,7 @@ class DemoResultContext:
     closed_trades: list[dict[str, object]]
     assumptions: list[str]
     chart_sections: list[str]
+    sample_size_warning: str | None = None
 
 
 @dataclass(slots=True)
@@ -187,6 +188,7 @@ def build_demo_result_context(report: BacktestReport) -> DemoResultContext:
         closed_trades=report.to_dict()["closed_trades"],
         assumptions=guide.notes,
         chart_sections=["summary", "trades", "equity_curve"],
+        sample_size_warning=report.sample_size_warning,
     )
 
 

--- a/src/quant_balance/web_demo.py
+++ b/src/quant_balance/web_demo.py
@@ -261,10 +261,16 @@ def render_result_section(result_context) -> str:
 
     assumptions = ''.join(f'<li>{escape(note)}</li>' for note in result_context.assumptions)
     chart_sections = ', '.join(result_context.chart_sections)
+    sample_size_warning = ""
+    if result_context.sample_size_warning:
+        sample_size_warning = (
+            f'<div class="error" data-testid="sample-size-warning">{escape(result_context.sample_size_warning)}</div>'
+        )
     return f"""
     <section class=\"card\" data-testid=\"demo-result\">
       <h2>回测结果</h2>
       <p class=\"hint\">稳定结果区锚点：summary / trades / assumptions / chart-sections</p>
+      {sample_size_warning}
       <div class=\"grid\">
         <div>
           <h3 data-testid=\"summary-heading\">Summary</h3>

--- a/tests/test_web_demo.py
+++ b/tests/test_web_demo.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from io import BytesIO
 from pathlib import Path
 
+from quant_balance.report import SHORT_SAMPLE_WARNING
 from quant_balance.web_demo import create_app, render_demo_page, run_demo_web_backtest
 
 
@@ -29,6 +30,7 @@ def test_run_demo_web_backtest_returns_summary_trades_and_assumptions() -> None:
     assert result.summary["final_equity"] > 0
     assert "summary" in result.chart_sections
     assert any("印花税" in note for note in result.assumptions)
+    assert result.sample_size_warning == SHORT_SAMPLE_WARNING
 
 
 def test_render_demo_page_shows_friendly_validation_error_for_invalid_ma_combo() -> None:
@@ -44,6 +46,21 @@ def test_render_demo_page_shows_friendly_validation_error_for_invalid_ma_combo()
 
     assert 'data-testid="demo-error"' in html
     assert "短均线必须小于长均线" in html
+
+
+def test_render_demo_page_shows_short_sample_warning_when_metrics_are_degraded() -> None:
+    html = render_demo_page(
+        form_data={
+            "input_mode": "example",
+            "symbol": "600519.SH",
+            "initial_cash": "100000",
+            "short_window": "5",
+            "long_window": "10",
+        }
+    )
+
+    assert 'data-testid="sample-size-warning"' in html
+    assert SHORT_SAMPLE_WARNING in html
 
 
 def test_create_app_handles_health_and_demo_post_flow(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

把短样本 warning 同步展示到 Web Demo 结果页，让页面用户能明确区分“主动降级”与“系统缺值”。

## Changes

- 将 `sample_size_warning` 透传到 `DemoResultContext`
- 在 Web Demo 结果区新增醒目的 warning 提示块
- 为该提示块增加稳定 selector：`data-testid="sample-size-warning"`
- 补充页面层回归测试，覆盖 warning 渲染行为

## Testing

- `PYTHONPATH=src pytest -q`（64 passed）
- 覆盖 Web Demo 页面 warning 的显示断言

Fixes zionwudt/quant-balance#35