### PR TITLE
feat: 为 Web Demo 增加真实 CSV 文件上传

### DIFF
--- a/src/quant_balance/web_demo.py
+++ b/src/quant_balance/web_demo.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import cgi
 from html import escape
 from pathlib import Path
 from typing import Callable
@@ -73,6 +74,7 @@ def render_demo_page(
     long_window = form_data.get("long_window", "20")
     csv_text = form_data.get("csv_text", "")
     csv_path = form_data.get("csv_path", "")
+    uploaded_filename = form_data.get("csv_filename", "")
 
     error_message = ""
     result_context = None
@@ -94,6 +96,10 @@ def render_demo_page(
             f'<input id="csv_path" name="csv_path" value="{escape(csv_path)}" data-testid="csv-path-input">'
             '</div>'
         )
+
+    upload_hint = "选择本地 CSV 文件上传；若暂时没有文件，也可继续粘贴 CSV 文本做调试。"
+    if uploaded_filename:
+        upload_hint = f"已选择文件：{uploaded_filename}"
 
     return f"""<!doctype html>
 <html lang=\"zh-CN\">
@@ -125,14 +131,14 @@ def render_demo_page(
   <main>
     <section class=\"card\" data-testid=\"demo-header\">
       <h1>QuantBalance 本地 Web Demo</h1>
-      <p>先把主人可直接点开的最小回测路径跑通：选择示例数据或粘贴 CSV，提交后直接看到 summary、trades 与关键假设说明。</p>
+      <p>先把主人可直接点开的最小回测路径跑通：选择示例数据或上传 CSV，提交后直接看到 summary、trades 与关键假设说明。</p>
     </section>
 
     <section class=\"card\" data-testid=\"demo-form\">
       <h2>回测表单</h2>
       {f'<div class="error" data-testid="demo-error">{escape(error_message)}</div>' if error_message else ''}
       {('<div class="success" data-testid="demo-success">已完成一次回测，可继续调整参数后再次提交。</div>' if result_context else '')}
-      <form method=\"post\" action=\"/demo\">
+      <form method=\"post\" action=\"/demo\" enctype=\"multipart/form-data\">
         <div>
           <label>数据来源</label>
           <div class=\"radio-group\" data-testid=\"input-mode-options\">
@@ -159,10 +165,16 @@ def render_demo_page(
         </div>
 
         <div style=\"margin-top: 16px;\">
-          <label for=\"csv_text\">上传 CSV 内容（先用文本粘贴模拟上传）</label>
-          <textarea id=\"csv_text\" name=\"csv_text\" data-testid=\"csv-upload-input\">{escape(csv_text)}</textarea>
-          <p class=\"hint\">当前 MVP 先用 textarea 作为浏览器上传入口占位，后续可无缝换成文件上传控件。</p>
+          <label for=\"csv_file\">上传 CSV 文件</label>
+          <input id=\"csv_file\" name=\"csv_file\" type=\"file\" accept=\".csv,text/csv\" data-testid=\"csv-file-input\">
+          <p class=\"hint\" data-testid=\"csv-upload-hint\">{escape(upload_hint)}</p>
         </div>
+
+        <details style=\"margin-top: 16px;\">
+          <summary>开发 / 调试辅助：直接粘贴 CSV 文本</summary>
+          <textarea id=\"csv_text\" name=\"csv_text\" data-testid=\"csv-upload-input\">{escape(csv_text)}</textarea>
+          <p class=\"hint\">上传文件会优先于文本粘贴路径；textarea 仅作为调试辅助保留。</p>
+        </details>
 
         {developer_path_block}
 
@@ -207,8 +219,9 @@ def run_demo_web_backtest(
 
     csv_text = None
     csv_path = None
+    uploaded_csv_text = form_data.get("csv_file_content", "")
     if input_mode == "upload":
-        csv_text = form_data.get("csv_text", "")
+        csv_text = uploaded_csv_text or form_data.get("csv_text", "")
     elif input_mode == "example":
         csv_text = example_csv_path.read_text(encoding="utf-8")
     elif input_mode == "path":
@@ -295,6 +308,10 @@ def render_result_section(result_context) -> str:
 
 
 def _parse_form_data(environ: dict[str, object]) -> dict[str, str]:
+    content_type = str(environ.get("CONTENT_TYPE") or "")
+    if content_type.startswith("multipart/form-data"):
+        return _parse_multipart_form_data(environ)
+
     content_length = int(str(environ.get("CONTENT_LENGTH") or 0) or 0)
     body = b""
     if content_length > 0:
@@ -305,6 +322,25 @@ def _parse_form_data(environ: dict[str, object]) -> dict[str, str]:
         return {}
     parsed = parse_qs(body.decode("utf-8"), keep_blank_values=True)
     return {key: values[-1] if values else "" for key, values in parsed.items()}
+
+
+
+def _parse_multipart_form_data(environ: dict[str, object]) -> dict[str, str]:
+    storage = cgi.FieldStorage(fp=environ.get("wsgi.input"), environ=environ, keep_blank_values=True)
+    form_data: dict[str, str] = {}
+    for key in storage.keys():
+        field = storage[key]
+        if isinstance(field, list):
+            field = field[-1]
+        if getattr(field, "filename", None):
+            file_bytes = field.file.read() if field.file else b""
+            form_data[f"{key}_content"] = file_bytes.decode("utf-8", errors="replace")
+            form_data[f"{key}_filename"] = field.filename or ""
+        else:
+            form_data[key] = field.value or ""
+    if "csv_file_filename" in form_data:
+        form_data["csv_filename"] = form_data["csv_file_filename"]
+    return form_data
 
 
 

--- a/tests/test_web_demo.py
+++ b/tests/test_web_demo.py
@@ -7,29 +7,41 @@ from quant_balance.report import SHORT_SAMPLE_WARNING
 from quant_balance.web_demo import create_app, render_demo_page, run_demo_web_backtest
 
 
-def test_render_demo_page_exposes_form_result_anchors_and_example_preview() -> None:
+def test_render_demo_page_exposes_real_file_upload_entry() -> None:
     html = render_demo_page()
 
-    assert 'data-testid="demo-form"' in html
-    assert 'data-testid="input-mode-options"' in html
-    assert 'data-testid="csv-template"' in html
-    assert 'data-testid="example-csv-preview"' in html
+    assert 'enctype="multipart/form-data"' in html
+    assert 'data-testid="csv-file-input"' in html
+    assert 'data-testid="csv-upload-input"' in html
+    assert 'data-testid="csv-upload-hint"' in html
 
 
-def test_run_demo_web_backtest_returns_summary_trades_and_assumptions() -> None:
+def test_run_demo_web_backtest_prefers_uploaded_file_content_for_upload_mode() -> None:
     result = run_demo_web_backtest(
         form_data={
-            "input_mode": "example",
+            "input_mode": "upload",
             "symbol": "600519.SH",
             "initial_cash": "100000",
             "short_window": "5",
             "long_window": "10",
+            "csv_file_content": (
+                "date,open,high,low,close,volume\n"
+                "2026-01-05,10,10.1,9.9,10,100000\n"
+                "2026-01-06,10.0,10.2,9.9,10.1,100000\n"
+                "2026-01-07,10.1,10.4,10.0,10.3,100000\n"
+                "2026-01-08,10.2,10.5,10.1,10.4,100000\n"
+                "2026-01-09,10.3,10.6,10.2,10.5,100000\n"
+                "2026-01-12,10.4,10.7,10.3,10.6,100000\n"
+                "2026-01-13,10.5,10.8,10.4,10.7,100000\n"
+                "2026-01-14,10.6,10.9,10.5,10.8,100000\n"
+                "2026-01-15,10.7,11.0,10.6,10.9,100000\n"
+                "2026-01-16,10.8,11.1,10.7,11.0,100000\n"
+            ),
+            "csv_filename": "bars.csv",
         }
     )
 
     assert result.summary["final_equity"] > 0
-    assert "summary" in result.chart_sections
-    assert any("印花税" in note for note in result.assumptions)
     assert result.sample_size_warning == SHORT_SAMPLE_WARNING
 
 
@@ -63,7 +75,7 @@ def test_render_demo_page_shows_short_sample_warning_when_metrics_are_degraded()
     assert SHORT_SAMPLE_WARNING in html
 
 
-def test_create_app_handles_health_and_demo_post_flow(tmp_path: Path) -> None:
+def test_create_app_handles_health_and_multipart_file_upload_flow(tmp_path: Path) -> None:
     example_csv = tmp_path / "example.csv"
     example_csv.write_text(
         "date,open,high,low,close,volume\n"
@@ -99,15 +111,47 @@ def test_create_app_handles_health_and_demo_post_flow(tmp_path: Path) -> None:
     assert captured["status"] == "200 OK"
     assert b"ok" == b"".join(health_response)
 
-    body = (
-        "input_mode=example&symbol=600519.SH&initial_cash=100000&short_window=5&long_window=10"
+    boundary = "----WebKitFormBoundary7MA4YWxkTrZu0gW"
+    multipart_body = (
+        f"--{boundary}\r\n"
+        'Content-Disposition: form-data; name="input_mode"\r\n\r\n'
+        'upload\r\n'
+        f"--{boundary}\r\n"
+        'Content-Disposition: form-data; name="symbol"\r\n\r\n'
+        '600519.SH\r\n'
+        f"--{boundary}\r\n"
+        'Content-Disposition: form-data; name="initial_cash"\r\n\r\n'
+        '100000\r\n'
+        f"--{boundary}\r\n"
+        'Content-Disposition: form-data; name="short_window"\r\n\r\n'
+        '5\r\n'
+        f"--{boundary}\r\n"
+        'Content-Disposition: form-data; name="long_window"\r\n\r\n'
+        '10\r\n'
+        f"--{boundary}\r\n"
+        'Content-Disposition: form-data; name="csv_file"; filename="bars.csv"\r\n'
+        'Content-Type: text/csv\r\n\r\n'
+        'date,open,high,low,close,volume\n'
+        '2026-01-05,10,10.1,9.9,10,100000\n'
+        '2026-01-06,10.0,10.2,9.9,10.1,100000\n'
+        '2026-01-07,10.1,10.4,10.0,10.3,100000\n'
+        '2026-01-08,10.2,10.5,10.1,10.4,100000\n'
+        '2026-01-09,10.3,10.6,10.2,10.5,100000\n'
+        '2026-01-12,10.4,10.7,10.3,10.6,100000\n'
+        '2026-01-13,10.5,10.8,10.4,10.7,100000\n'
+        '2026-01-14,10.6,10.9,10.5,10.8,100000\n'
+        '2026-01-15,10.7,11.0,10.6,10.9,100000\n'
+        '2026-01-16,10.8,11.1,10.7,11.0,100000\r\n'
+        f"--{boundary}--\r\n"
     ).encode("utf-8")
+
     page_response = app(
         {
             "REQUEST_METHOD": "POST",
             "PATH_INFO": "/demo",
-            "wsgi.input": BytesIO(body),
-            "CONTENT_LENGTH": str(len(body)),
+            "CONTENT_TYPE": f"multipart/form-data; boundary={boundary}",
+            "wsgi.input": BytesIO(multipart_body),
+            "CONTENT_LENGTH": str(len(multipart_body)),
         },
         start_response,
     )
@@ -117,3 +161,4 @@ def test_create_app_handles_health_and_demo_post_flow(tmp_path: Path) -> None:
     assert 'data-testid="demo-result"' in html
     assert 'data-testid="summary-table"' in html
     assert 'data-testid="trades-table"' in html
+    assert '已选择文件：bars.csv' in html


### PR DESCRIPTION
## Summary

把当前 Web Demo 的“上传 CSV”路径从 textarea 占位升级为真实文件上传入口，让页面核心路径更接近普通用户实际使用方式。

## Changes

- 将表单改为 `multipart/form-data`
- 新增真实文件选择器，支持上传本地 CSV 文件
- 上传模式下优先使用 `csv_file` 的内容，仍保留 textarea 作为开发/调试辅助
- 页面会显示当前已选择的文件名
- 补充 multipart 上传路径的页面级回归测试

## Testing

- `PYTHONPATH=src pytest -q`（64 passed）
- 覆盖真实 multipart 文件上传 happy path

## Note

当前实现使用标准库 `cgi.FieldStorage` 解析 multipart，请求路径已可用；后续如果仓库要显式兼容 Python 3.13+，可以再把这层替换成不依赖 `cgi` 的解析方式。

Fixes zionwudt/quant-balance#37