### PR TITLE
fix: 优化 demo CLI 的用户级错误提示

### DIFF
--- a/src/quant_balance/cli.py
+++ b/src/quant_balance/cli.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
 
 from quant_balance.backtest import BacktestEngine
-from quant_balance.demo import parse_csv_text_to_bars
+from quant_balance.demo import DemoValidationError, parse_csv_text_to_bars
 from quant_balance.models import AccountConfig
 from quant_balance.report import BacktestReport
 from quant_balance.strategy import MovingAverageCrossStrategy
@@ -41,13 +42,17 @@ def run_cli(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if args.command == "demo":
-        report = run_demo_backtest(
-            csv_path=Path(args.csv),
-            symbol=args.symbol,
-            initial_cash=args.initial_cash,
-            short_window=args.short_window,
-            long_window=args.long_window,
-        )
+        try:
+            report = run_demo_backtest(
+                csv_path=Path(args.csv),
+                symbol=args.symbol,
+                initial_cash=args.initial_cash,
+                short_window=args.short_window,
+                long_window=args.long_window,
+            )
+        except (ValueError, FileNotFoundError, DemoValidationError) as exc:
+            print(f"错误：{_format_demo_cli_error(exc, csv_path=Path(args.csv))}", file=sys.stderr)
+            return 2
 
         if args.json:
             print(json.dumps(report.to_dict(), ensure_ascii=False, indent=2))
@@ -78,9 +83,14 @@ def run_demo_backtest(
     long_window: int,
 ) -> BacktestReport:
     if initial_cash <= 0:
-        raise ValueError("initial cash must be greater than 0")
-    if short_window < 2 or long_window < 3 or short_window >= long_window:
-        raise ValueError("invalid moving average windows: short_window must be >= 2 and < long_window")
+        raise DemoValidationError("初始资金必须大于 0。")
+    if short_window < 2 or long_window < 3:
+        raise DemoValidationError("均线参数过小，建议短均线 ≥ 2、长均线 ≥ 3。")
+    if short_window >= long_window:
+        raise DemoValidationError("短均线必须小于长均线。")
+
+    if not csv_path.exists():
+        raise FileNotFoundError(csv_path)
 
     csv_text = csv_path.read_text(encoding="utf-8")
     bars = parse_csv_text_to_bars(csv_text=csv_text, symbol=symbol)
@@ -91,6 +101,14 @@ def run_demo_backtest(
     if result.report is None:
         raise RuntimeError("backtest did not produce a report")
     return result.report
+
+
+def _format_demo_cli_error(exc: Exception, *, csv_path: Path) -> str:
+    if isinstance(exc, FileNotFoundError):
+        missing_path = Path(getattr(exc, "filename", "") or csv_path)
+        return f"找不到 CSV 文件 {missing_path}。"
+    return str(exc)
+
 
 
 def format_demo_summary(report: BacktestReport, *, csv_path: Path, symbol: str, short_window: int, long_window: int) -> str:

--- a/tests/test_cli_demo_errors.py
+++ b/tests/test_cli_demo_errors.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_demo_cli_returns_user_friendly_error_for_invalid_ma_combo() -> None:
+    root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [sys.executable, "-m", "quant_balance.main", "demo", "--short-window", "20", "--long-window", "10"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(root / 'src')},
+    )
+
+    assert result.returncode != 0
+    assert "错误：短均线必须小于长均线。" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+def test_demo_cli_returns_user_friendly_error_for_missing_csv() -> None:
+    root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [sys.executable, "-m", "quant_balance.main", "demo", "--csv", "/tmp/not-found.csv"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(root / 'src')},
+    )
+
+    assert result.returncode != 0
+    assert "错误：找不到 CSV 文件 /tmp/not-found.csv。" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+def test_demo_cli_returns_user_friendly_error_for_invalid_csv_content(tmp_path: Path) -> None:
+    root = Path(__file__).resolve().parents[1]
+    bad_csv = tmp_path / "bad.csv"
+    bad_csv.write_text("date,open,high,low,close\n2026-01-05,10,11,9,10.5\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, "-m", "quant_balance.main", "demo", "--csv", str(bad_csv)],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(root / 'src')},
+    )
+
+    assert result.returncode != 0
+    assert "错误：CSV 缺少必要字段：volume。请下载模板后按模板列名准备数据。" in result.stderr
+    assert "Traceback" not in result.stderr


### PR DESCRIPTION
## Summary

让 `quant-balance demo` 在遇到可预期的用户输入错误时，返回用户可读提示和非零退出码，而不是直接抛 Python traceback。

## Changes

- 将 demo CLI 的参数/输入错误收敛为中文错误提示
- 对文件不存在、均线参数不合理、CSV 校验失败等场景返回非 0 退出码
- 尽量复用现有 Demo / Web Demo 的中文校验语义
- 新增错误路径回归测试，覆盖 invalid MA、missing CSV、invalid CSV content

## Testing

- `PYTHONPATH=src pytest -q`（67 passed）
- 覆盖 CLI 错误路径不再出现 traceback

Fixes zionwudt/quant-balance#43