### PR TITLE
feat: 补齐 quant_balance 模块入口

### DIFF
--- a/src/quant_balance/__main__.py
+++ b/src/quant_balance/__main__.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from quant_balance.main import main
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_module_entrypoint.py
+++ b/tests/test_module_entrypoint.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_python_dash_m_quant_balance_help_works() -> None:
+    root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [sys.executable, "-m", "quant_balance", "--help"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(root / 'src')},
+    )
+
+    help_text = result.stdout
+
+    assert "demo" in help_text
+    assert "web-demo" in help_text
+    assert "QuantBalance CLI" in help_text


### PR DESCRIPTION
## Summary

补齐 `quant_balance.__main__`，让 `python -m quant_balance` 成为正式可用入口，避免 Python 用户首用时直接遇到模块不可执行报错。

## Changes

- 新增 `src/quant_balance/__main__.py`
- 直接复用现有 `quant_balance.main.main`
- 新增 `python -m quant_balance --help` smoke test

## Testing

- `PYTHONPATH=src pytest -q`（65 passed）
- 覆盖 `python -m quant_balance --help` 输出

Fixes zionwudt/quant-balance#42