### PR TITLE
test: 为 Web Demo 选择器契约补齐自动化回归

### DIFF
--- a/src/quant_balance/web_demo.py
+++ b/src/quant_balance/web_demo.py
@@ -122,52 +122,52 @@ def render_demo_page(
   </style>
 </head>
 <body>
-  <main>
-    <section class=\"card\" data-testid=\"demo-header\">
+  <main data-testid=\"qb-demo-page\">
+    <section class=\"card\" data-testid=\"qb-demo-header\">
       <h1>QuantBalance 本地 Web Demo</h1>
       <p>先把主人可直接点开的最小回测路径跑通：选择示例数据或粘贴 CSV，提交后直接看到 summary、trades 与关键假设说明。</p>
     </section>
 
-    <section class=\"card\" data-testid=\"demo-form\">
+    <section class=\"card\" data-testid=\"qb-demo-form\">
       <h2>回测表单</h2>
-      {f'<div class="error" data-testid="demo-error">{escape(error_message)}</div>' if error_message else ''}
-      {('<div class="success" data-testid="demo-success">已完成一次回测，可继续调整参数后再次提交。</div>' if result_context else '')}
+      {f'<div class="error" data-testid="qb-demo-error">{escape(error_message)}</div>' if error_message else '<div data-testid="qb-demo-error" hidden></div>'}
+      {('<div class="success" data-testid="qb-demo-success">已完成一次回测，可继续调整参数后再次提交。</div>' if result_context else '')}
       <form method=\"post\" action=\"/demo\">
         <div>
           <label>数据来源</label>
-          <div class=\"radio-group\" data-testid=\"input-mode-options\">
+          <div class=\"radio-group\" data-testid=\"qb-input-mode\">
             {''.join(_render_mode_option(option['mode'], option['label'], selected_mode) for option in page_context.input_options)}
           </div>
         </div>
         <div class=\"grid\" style=\"margin-top: 16px;\">
           <div>
             <label for=\"symbol\">股票代码</label>
-            <input id=\"symbol\" name=\"symbol\" value=\"{escape(symbol)}\" data-testid=\"symbol-input\">
+            <input id=\"symbol\" name=\"symbol\" value=\"{escape(symbol)}\" data-testid=\"qb-symbol-input\">
           </div>
           <div>
             <label for=\"initial_cash\">初始资金</label>
-            <input id=\"initial_cash\" name=\"initial_cash\" value=\"{escape(initial_cash)}\" data-testid=\"initial-cash-input\">
+            <input id=\"initial_cash\" name=\"initial_cash\" value=\"{escape(initial_cash)}\" data-testid=\"qb-initial-cash-input\">
           </div>
           <div>
             <label for=\"short_window\">短均线</label>
-            <input id=\"short_window\" name=\"short_window\" value=\"{escape(short_window)}\" data-testid=\"short-window-input\">
+            <input id=\"short_window\" name=\"short_window\" value=\"{escape(short_window)}\" data-testid=\"qb-short-window-input\">
           </div>
           <div>
             <label for=\"long_window\">长均线</label>
-            <input id=\"long_window\" name=\"long_window\" value=\"{escape(long_window)}\" data-testid=\"long-window-input\">
+            <input id=\"long_window\" name=\"long_window\" value=\"{escape(long_window)}\" data-testid=\"qb-long-window-input\">
           </div>
         </div>
 
         <div style=\"margin-top: 16px;\">
           <label for=\"csv_text\">上传 CSV 内容（先用文本粘贴模拟上传）</label>
-          <textarea id=\"csv_text\" name=\"csv_text\" data-testid=\"csv-upload-input\">{escape(csv_text)}</textarea>
+          <textarea id=\"csv_text\" name=\"csv_text\" data-testid=\"qb-upload-input\">{escape(csv_text)}</textarea>
           <p class=\"hint\">当前 MVP 先用 textarea 作为浏览器上传入口占位，后续可无缝换成文件上传控件。</p>
         </div>
 
         {developer_path_block}
 
         <div style=\"margin-top: 18px; display: flex; gap: 12px; flex-wrap: wrap;\">
-          <button type=\"submit\" data-testid=\"submit-backtest\">运行回测</button>
+          <button type=\"submit\" data-testid=\"qb-submit-backtest\">运行回测</button>
         </div>
       </form>
     </section>
@@ -264,26 +264,26 @@ def render_result_section(result_context) -> str:
     sample_size_warning = ""
     if result_context.sample_size_warning:
         sample_size_warning = (
-            f'<div class="error" data-testid="sample-size-warning">{escape(result_context.sample_size_warning)}</div>'
+            f'<div class="error" data-testid="qb-sample-size-warning">{escape(result_context.sample_size_warning)}</div>'
         )
     return f"""
-    <section class=\"card\" data-testid=\"demo-result\">
+    <section class=\"card\" data-testid=\"qb-result-panel\">
       <h2>回测结果</h2>
       <p class=\"hint\">稳定结果区锚点：summary / trades / assumptions / chart-sections</p>
       {sample_size_warning}
       <div class=\"grid\">
         <div>
-          <h3 data-testid=\"summary-heading\">Summary</h3>
-          <table data-testid=\"summary-table\">{summary_rows}</table>
+          <h3 data-testid=\"qb-summary-heading\">Summary</h3>
+          <table data-testid=\"qb-result-summary\">{summary_rows}</table>
         </div>
         <div>
-          <h3 data-testid=\"assumptions-heading\">关键假设说明</h3>
-          <ul data-testid=\"assumptions-list\">{assumptions}</ul>
-          <p data-testid=\"chart-sections\">预留图表区块：{escape(chart_sections)}</p>
+          <h3 data-testid=\"qb-assumptions-heading\">关键假设说明</h3>
+          <ul data-testid=\"qb-result-assumptions\">{assumptions}</ul>
+          <p data-testid=\"qb-chart-sections\">预留图表区块：{escape(chart_sections)}</p>
         </div>
       </div>
-      <h3 data-testid=\"trades-heading\">Closed Trades</h3>
-      <table data-testid=\"trades-table\">
+      <h3 data-testid=\"qb-trades-heading\">Closed Trades</h3>
+      <table data-testid=\"qb-result-trades\">
         <thead>
           <tr><th>Symbol</th><th>Entry</th><th>Exit</th><th>Qty</th><th>Entry Px</th><th>Exit Px</th><th>PnL</th><th>PnL %</th></tr>
         </thead>
@@ -310,7 +310,8 @@ def _parse_form_data(environ: dict[str, object]) -> dict[str, str]:
 
 def _render_mode_option(mode: str, label: str, selected_mode: str) -> str:
     checked = "checked" if selected_mode == mode else ""
-    return f'<label><input type="radio" name="input_mode" value="{escape(mode)}" {checked}> {escape(label)}</label>'
+    extra_testid = ' data-testid="qb-use-example"' if mode == "example" else ""
+    return f'<label{extra_testid}><input type="radio" name="input_mode" value="{escape(mode)}" {checked}> {escape(label)}</label>'
 
 
 

--- a/tests/test_demo_selector_contract.py
+++ b/tests/test_demo_selector_contract.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from io import BytesIO
+from pathlib import Path
+
+from quant_balance.demo import get_demo_stable_selectors
+from quant_balance.web_demo import create_app, render_demo_page
+
+
+def _render_success_html() -> str:
+    return render_demo_page(
+        form_data={
+            "input_mode": "example",
+            "symbol": "600519.SH",
+            "initial_cash": "100000",
+            "short_window": "5",
+            "long_window": "10",
+        }
+    )
+
+
+def test_selector_contract_markers_exist_on_home_page() -> None:
+    html = render_demo_page()
+
+    assert 'data-testid="qb-demo-page"' in html
+    assert 'data-testid="qb-input-mode"' in html
+    assert 'data-testid="qb-upload-input"' in html
+    assert 'data-testid="qb-submit-backtest"' in html
+    assert 'data-testid="qb-demo-error"' in html
+
+
+
+def test_selector_contract_markers_exist_on_success_result_page() -> None:
+    html = _render_success_html()
+
+    assert 'data-testid="qb-result-summary"' in html
+    assert 'data-testid="qb-result-trades"' in html
+    assert 'data-testid="qb-result-assumptions"' in html
+
+
+
+def test_selector_contract_markers_exist_on_validation_error_page() -> None:
+    html = render_demo_page(
+        form_data={
+            "input_mode": "example",
+            "symbol": "600519.SH",
+            "initial_cash": "100000",
+            "short_window": "20",
+            "long_window": "10",
+        }
+    )
+
+    assert 'data-testid="qb-demo-error"' in html
+    assert "短均线必须小于长均线" in html
+
+
+
+def test_selector_contract_definition_and_wsgi_response_stay_in_sync(tmp_path: Path) -> None:
+    example_csv = tmp_path / "example.csv"
+    example_csv.write_text(
+        "date,open,high,low,close,volume\n"
+        "2026-01-05,10,10.1,9.9,10,100000\n"
+        "2026-01-06,10,10.2,9.9,10.1,100000\n"
+        "2026-01-07,10.1,10.4,10.0,10.3,100000\n"
+        "2026-01-08,10.2,10.5,10.1,10.4,100000\n",
+        encoding="utf-8",
+    )
+    app = create_app(example_csv_path=example_csv)
+
+    captured: dict[str, object] = {}
+
+    def start_response(status: str, headers: list[tuple[str, str]]) -> None:
+        captured["status"] = status
+        captured["headers"] = headers
+
+    body = b"input_mode=example&symbol=600519.SH&initial_cash=100000&short_window=5&long_window=10"
+    response = app(
+        {
+            "REQUEST_METHOD": "POST",
+            "PATH_INFO": "/demo",
+            "wsgi.input": BytesIO(body),
+            "CONTENT_LENGTH": str(len(body)),
+        },
+        start_response,
+    )
+    html = b"".join(response).decode("utf-8")
+
+    assert captured["status"] == "200 OK"
+    for selector in get_demo_stable_selectors():
+        marker = selector.selector.replace("[data-testid='", 'data-testid="').replace("']", '"')
+        assert marker in html, f"missing selector contract marker: {selector.selector}"

--- a/tests/test_web_demo.py
+++ b/tests/test_web_demo.py
@@ -10,10 +10,10 @@ from quant_balance.web_demo import create_app, render_demo_page, run_demo_web_ba
 def test_render_demo_page_exposes_form_result_anchors_and_example_preview() -> None:
     html = render_demo_page()
 
-    assert 'data-testid="demo-form"' in html
-    assert 'data-testid="input-mode-options"' in html
-    assert 'data-testid="csv-template"' in html
-    assert 'data-testid="example-csv-preview"' in html
+    assert 'data-testid="qb-demo-page"' in html
+    assert 'data-testid="qb-demo-form"' in html
+    assert 'data-testid="qb-input-mode"' in html
+    assert 'data-testid="qb-upload-input"' in html
 
 
 def test_run_demo_web_backtest_returns_summary_trades_and_assumptions() -> None:
@@ -44,7 +44,7 @@ def test_render_demo_page_shows_friendly_validation_error_for_invalid_ma_combo()
         }
     )
 
-    assert 'data-testid="demo-error"' in html
+    assert 'data-testid="qb-demo-error"' in html
     assert "短均线必须小于长均线" in html
 
 
@@ -59,7 +59,7 @@ def test_render_demo_page_shows_short_sample_warning_when_metrics_are_degraded()
         }
     )
 
-    assert 'data-testid="sample-size-warning"' in html
+    assert 'data-testid="qb-sample-size-warning"' in html
     assert SHORT_SAMPLE_WARNING in html
 
 
@@ -114,6 +114,7 @@ def test_create_app_handles_health_and_demo_post_flow(tmp_path: Path) -> None:
     html = b"".join(page_response).decode("utf-8")
 
     assert captured["status"] == "200 OK"
-    assert 'data-testid="demo-result"' in html
-    assert 'data-testid="summary-table"' in html
-    assert 'data-testid="trades-table"' in html
+    assert 'data-testid="qb-result-panel"' in html
+    assert 'data-testid="qb-result-summary"' in html
+    assert 'data-testid="qb-result-trades"' in html
+    assert 'data-testid="qb-result-assumptions"' in html


### PR DESCRIPTION
## Summary

把 Web Demo 的稳定 selector contract 变成 pytest 可拦截的硬约束，避免 docs / 实现 / 自动化三方再次漂移。

## Changes

- 新增 `tests/test_demo_selector_contract.py`
- 覆盖首页、成功回测页、校验错误页三类关键 selector 场景
- 让测试直接对照 `get_demo_stable_selectors()` 校验渲染 HTML
- 同步把当前页面实现与 `qb-*` selector 契约对齐
- 更新现有 Web Demo 测试中的锚点断言

## Testing

- `PYTHONPATH=src pytest -q`（68 passed）
- 其中 selector contract 专项测试 4 passed

Fixes zionwudt/quant-balance#47