### PR TITLE
fix: 前置校验 web-demo 的 example-csv 路径

### DIFF
--- a/src/quant_balance/cli.py
+++ b/src/quant_balance/cli.py
@@ -62,12 +62,16 @@ def run_cli(argv: list[str] | None = None) -> int:
         return 0
 
     if args.command == "web-demo":
+        example_csv_path = Path(args.example_csv)
+        if not example_csv_path.exists():
+            print(f"错误：找不到示例 CSV 文件 {example_csv_path}。请检查 --example-csv 参数。", file=sys.stderr)
+            return 2
         run_demo_web_server(
             host=args.host,
             port=args.port,
             developer_mode=args.developer_mode,
             open_browser=args.open_browser,
-            example_csv_path=Path(args.example_csv),
+            example_csv_path=example_csv_path,
         )
         return 0
 

--- a/tests/test_web_demo_cli_errors.py
+++ b/tests/test_web_demo_cli_errors.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_web_demo_cli_returns_user_friendly_error_for_missing_example_csv() -> None:
+    root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "quant_balance.main",
+            "web-demo",
+            "--example-csv",
+            "/tmp/no-such.csv",
+        ],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(root / 'src')},
+    )
+
+    assert result.returncode != 0
+    assert "错误：找不到示例 CSV 文件 /tmp/no-such.csv。请检查 --example-csv 参数。" in result.stderr
+    assert "Traceback" not in result.stderr


### PR DESCRIPTION
## Summary

把 `web-demo --example-csv` 的无效路径错误前置到 CLI 启动阶段处理，避免服务虽然启动了，但用户第一次访问 `/demo` 才炸成 500。

## Changes

- 在 `web-demo` 启动前校验 `--example-csv` 是否存在
- 若路径无效，直接返回用户可读错误与非 0 退出码
- 避免把可预期的本地配置错误暴露成页面 500
- 补充对应 CLI 回归测试

## Testing

- `PYTHONPATH=src pytest -q`（73 passed）
- 覆盖 `web-demo --example-csv /tmp/no-such.csv` 错误路径

Fixes zionwudt/quant-balance#48