### PR TITLE
feat: 增强 Web Demo 结果页的可复盘性

### DIFF
--- a/src/quant_balance/demo.py
+++ b/src/quant_balance/demo.py
@@ -4,6 +4,7 @@ from dataclasses import asdict, dataclass
 from datetime import date
 import csv
 import io
+import json
 
 from quant_balance.models import MarketBar
 from quant_balance.report import BacktestReport
@@ -73,6 +74,9 @@ class DemoResultContext:
     assumptions: list[str]
     chart_sections: list[str]
     sample_size_warning: str | None = None
+    run_context: dict[str, object] | None = None
+    export_json: str | None = None
+    equity_curve_points: list[dict[str, object]] | None = None
 
 
 @dataclass(slots=True)
@@ -163,7 +167,12 @@ def build_demo_page_context(*, developer_mode: bool = False) -> DemoPageContext:
 
 
 
-def build_demo_result_context(report: BacktestReport) -> DemoResultContext:
+def build_demo_result_context(
+    report: BacktestReport,
+    *,
+    run_context: dict[str, object] | None = None,
+    equity_curve_points: list[dict[str, object]] | None = None,
+) -> DemoResultContext:
     guide = get_demo_field_guide()
     summary: dict[str, float | int | str | None] = {
         "initial_equity": report.initial_equity,
@@ -183,12 +192,22 @@ def build_demo_result_context(report: BacktestReport) -> DemoResultContext:
         "benchmark_return_pct": report.benchmark_return_pct,
         "excess_return_pct": report.excess_return_pct,
     }
+    export_payload = {
+        "summary": summary,
+        "closed_trades": report.to_dict()["closed_trades"],
+        "run_context": run_context or {},
+        "assumptions": guide.notes,
+        "sample_size_warning": report.sample_size_warning,
+    }
     return DemoResultContext(
         summary=summary,
         closed_trades=report.to_dict()["closed_trades"],
         assumptions=guide.notes,
-        chart_sections=["summary", "trades", "equity_curve"],
+        chart_sections=["summary", "trades", "equity_curve", "run_context", "export"],
         sample_size_warning=report.sample_size_warning,
+        run_context=run_context or {},
+        export_json=json.dumps(export_payload, ensure_ascii=False, indent=2),
+        equity_curve_points=equity_curve_points or [],
     )
 
 
@@ -317,7 +336,6 @@ def build_demo_acceptance_checklist() -> DemoAcceptanceChecklist:
     )
 
 
-
 def load_demo_bars(request: BacktestDemoRequest) -> list[MarketBar]:
     request.validate()
     if request.input_mode == "example":
@@ -338,57 +356,58 @@ def load_demo_bars(request: BacktestDemoRequest) -> list[MarketBar]:
 
 
 def parse_csv_text_to_bars(*, csv_text: str, symbol: str) -> list[MarketBar]:
-    reader = csv.DictReader(io.StringIO(csv_text.strip()), skipinitialspace=True)
+    reader = csv.DictReader(io.StringIO(csv_text.strip()))
     if reader.fieldnames is None:
-        raise DemoValidationError("CSV 为空，或缺少表头。")
+        raise DemoValidationError("CSV 缺少表头，请至少包含 date, open, high, low, close, volume。")
 
-    reader.fieldnames = [name.strip() for name in reader.fieldnames]
-    fieldnames = set(reader.fieldnames)
-    missing_columns = [column for column in REQUIRED_CSV_COLUMNS if column not in fieldnames]
+    normalized_fieldnames = [field.strip() for field in reader.fieldnames]
+    missing_columns = [column for column in REQUIRED_CSV_COLUMNS if column not in normalized_fieldnames]
     if missing_columns:
-        raise DemoValidationError(
-            "CSV 缺少必要字段：" + ", ".join(missing_columns) + "。请下载模板后按模板列名准备数据。"
-        )
+        raise DemoValidationError(f"CSV 缺少必要字段：{', '.join(missing_columns)}。请下载模板后按模板列名准备数据。")
 
     bars: list[MarketBar] = []
-    previous_date: date | None = None
     seen_dates: set[date] = set()
-    try:
-        for raw_row in reader:
-            row = {(key or "").strip(): value for key, value in raw_row.items()}
-            bar = MarketBar(
+    previous_date: date | None = None
+
+    for index, raw_row in enumerate(reader, start=2):
+        row = {(key.strip() if key else key): value for key, value in raw_row.items()}
+        try:
+            bar_date = date.fromisoformat((row["date"] or "").strip())
+            open_price = float((row["open"] or "").strip())
+            high_price = float((row["high"] or "").strip())
+            low_price = float((row["low"] or "").strip())
+            close_price = float((row["close"] or "").strip())
+            volume = float((row["volume"] or "").strip())
+        except (TypeError, ValueError) as exc:
+            raise DemoValidationError(f"第 {index} 行存在无法识别的数值或日期格式，请检查 date/open/high/low/close/volume。") from exc
+
+        if previous_date and bar_date < previous_date:
+            raise DemoValidationError(f"CSV 日期顺序不正确：第 {index} 行 {bar_date.isoformat()} 早于上一行 {previous_date.isoformat()}。")
+        if bar_date in seen_dates:
+            raise DemoValidationError(f"CSV 存在重复交易日：{bar_date.isoformat()}。")
+        if min(open_price, high_price, low_price, close_price) <= 0:
+            raise DemoValidationError(f"第 {index} 行价格必须全部大于 0。")
+        if volume < 0:
+            raise DemoValidationError(f"第 {index} 行成交量不能为负数。")
+        if high_price < low_price:
+            raise DemoValidationError(f"第 {index} 行价格区间不合法：high 不能小于 low。")
+        if not (low_price <= open_price <= high_price):
+            raise DemoValidationError(f"第 {index} 行 open 必须落在 low 和 high 之间。")
+        if not (low_price <= close_price <= high_price):
+            raise DemoValidationError(f"第 {index} 行 close 必须落在 low 和 high 之间。")
+
+        bars.append(
+            MarketBar(
                 symbol=symbol,
-                date=date.fromisoformat((row["date"] or "").strip()),
-                open=float(row["open"]),
-                high=float(row["high"]),
-                low=float(row["low"]),
-                close=float(row["close"]),
-                volume=float(row["volume"]),
+                date=bar_date,
+                open=open_price,
+                high=high_price,
+                low=low_price,
+                close=close_price,
+                volume=volume,
             )
-
-            if previous_date and bar.date < previous_date:
-                raise DemoValidationError("CSV 日期顺序不正确：请按交易日从早到晚排列，不要乱序。")
-            if bar.date in seen_dates:
-                raise DemoValidationError("CSV 存在重复交易日：同一个日期只能出现一行数据。")
-            if min(bar.open, bar.high, bar.low, bar.close) <= 0:
-                raise DemoValidationError("CSV 价格必须全部大于 0，请检查 open/high/low/close 列。")
-            if bar.volume < 0:
-                raise DemoValidationError("CSV 成交量不能为负数，请检查 volume 列。")
-            if bar.high < bar.low:
-                raise DemoValidationError("CSV 价格区间不合法：high 不能小于 low。")
-            if not (bar.low <= bar.open <= bar.high):
-                raise DemoValidationError("CSV 价格区间不合法：open 必须落在 low 和 high 之间。")
-            if not (bar.low <= bar.close <= bar.high):
-                raise DemoValidationError("CSV 价格区间不合法：close 必须落在 low 和 high 之间。")
-
-            bars.append(bar)
-            previous_date = bar.date
-            seen_dates.add(bar.date)
-    except DemoValidationError:
-        raise
-    except (KeyError, ValueError) as exc:
-        raise DemoValidationError(
-            "CSV 中存在无法识别的数值或日期格式。请使用 YYYY-MM-DD 日期，并确保价格/成交量列都是数字。"
-        ) from exc
+        )
+        previous_date = bar_date
+        seen_dates.add(bar_date)
 
     return bars

--- a/src/quant_balance/web_demo.py
+++ b/src/quant_balance/web_demo.py
@@ -130,6 +130,9 @@ def render_demo_page(
     code, pre {{ background: #f3f4f6; border-radius: 8px; }}
     pre {{ padding: 12px; overflow-x: auto; white-space: pre-wrap; }}
     ul {{ padding-left: 18px; }}
+    .export-box {{ max-height: 260px; overflow: auto; }}
+    .context-list dt {{ font-weight: 700; margin-top: 8px; }}
+    .context-list dd {{ margin: 2px 0 8px 0; color: #374151; }}
   </style>
 </head>
 <body>
@@ -246,7 +249,22 @@ def run_demo_web_backtest(
     result = engine.run(bars)
     if result.report is None:
         raise RuntimeError("回测未生成 report")
-    return build_demo_result_context(result.report)
+
+    run_context = {
+        "input_mode": input_mode,
+        "symbol": symbol,
+        "initial_cash": initial_cash,
+        "short_window": short_window,
+        "long_window": long_window,
+        "bars_count": len(bars),
+        "date_range_start": bars[0].date.isoformat() if bars else None,
+        "date_range_end": bars[-1].date.isoformat() if bars else None,
+    }
+    equity_curve_points = [
+        {"date": equity_date.isoformat(), "equity": equity}
+        for equity_date, equity in zip(result.equity_dates, result.equity_curve)
+    ]
+    return build_demo_result_context(result.report, run_context=run_context, equity_curve_points=equity_curve_points)
 
 
 
@@ -281,6 +299,15 @@ def render_result_section(result_context) -> str:
         sample_size_warning = (
             f'<div class="error" data-testid="qb-sample-size-warning">{escape(result_context.sample_size_warning)}</div>'
         )
+
+    run_context = result_context.run_context or {}
+    context_items = ''.join(
+        f'<dt>{escape(str(key))}</dt><dd>{escape(_format_value(value))}</dd>'
+        for key, value in run_context.items()
+    )
+    export_json = escape(result_context.export_json or "")
+    equity_svg = _render_equity_curve_svg(result_context.equity_curve_points or [])
+
     return f"""
     <section class=\"card\" data-testid=\"qb-result-panel\">
       <h2>回测结果</h2>
@@ -297,6 +324,20 @@ def render_result_section(result_context) -> str:
           <p data-testid=\"qb-chart-sections\">预留图表区块：{escape(chart_sections)}</p>
         </div>
       </div>
+      <div class=\"grid\" style=\"margin-top: 16px;\">
+        <div>
+          <h3 data-testid=\"qb-equity-curve-heading\">权益曲线（轻量 SVG）</h3>
+          <div data-testid=\"qb-equity-curve\">{equity_svg}</div>
+        </div>
+        <div>
+          <h3 data-testid=\"qb-run-context-heading\">本次回测上下文</h3>
+          <dl class=\"context-list\" data-testid=\"qb-run-context\">{context_items}</dl>
+        </div>
+      </div>
+      <div style=\"margin-top: 16px;\">
+        <h3 data-testid=\"qb-export-heading\">结果导出（JSON 快照）</h3>
+        <pre class=\"export-box\" data-testid=\"qb-export-json\">{export_json}</pre>
+      </div>
       <h3 data-testid=\"qb-trades-heading\">Closed Trades</h3>
       <table data-testid=\"qb-result-trades\">
         <thead>
@@ -306,6 +347,34 @@ def render_result_section(result_context) -> str:
       </table>
     </section>
     """
+
+
+
+def _render_equity_curve_svg(points: list[dict[str, object]]) -> str:
+    if not points:
+        return "<p>暂无权益曲线数据。</p>"
+    width = 520
+    height = 180
+    padding = 20
+    equities = [float(point["equity"]) for point in points]
+    min_equity = min(equities)
+    max_equity = max(equities)
+    span = max(max_equity - min_equity, 1.0)
+    x_step = (width - padding * 2) / max(len(points) - 1, 1)
+    coords: list[str] = []
+    for index, point in enumerate(points):
+        x = padding + index * x_step
+        y = height - padding - ((float(point["equity"]) - min_equity) / span) * (height - padding * 2)
+        coords.append(f"{x:.1f},{y:.1f}")
+    polyline = " ".join(coords)
+    return (
+        f'<svg viewBox="0 0 {width} {height}" width="100%" height="180" role="img" aria-label="equity curve">'
+        f'<rect x="0" y="0" width="{width}" height="{height}" fill="#f8fafc" rx="12"></rect>'
+        f'<polyline fill="none" stroke="#2563eb" stroke-width="3" points="{polyline}"></polyline>'
+        f'<text x="{padding}" y="18" fill="#475569" font-size="12">min {min_equity:.2f}</text>'
+        f'<text x="{width - 120}" y="18" fill="#475569" font-size="12">max {max_equity:.2f}</text>'
+        '</svg>'
+    )
 
 
 

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -114,12 +114,15 @@ def test_build_demo_result_context_exposes_summary_trades_and_assumptions() -> N
 
     context = build_demo_result_context(report)
 
-    assert context.chart_sections == ["summary", "trades", "equity_curve"]
+    assert context.chart_sections == ["summary", "trades", "equity_curve", "run_context", "export"]
     assert context.summary["benchmark_name"] == "CSI300"
     assert context.summary["max_drawdown_start"] == "2026-01-06"
     assert context.summary["max_drawdown_end"] == "2026-01-07"
     assert context.closed_trades == []
     assert any("滑点" in note for note in context.assumptions)
+    assert context.export_json is not None
+    assert context.run_context == {}
+    assert context.equity_curve_points == []
 
 
 def test_build_demo_acceptance_checklist_covers_core_browser_paths() -> None:

--- a/tests/test_web_demo.py
+++ b/tests/test_web_demo.py
@@ -16,7 +16,7 @@ def test_render_demo_page_exposes_form_result_anchors_and_example_preview() -> N
     assert 'data-testid="qb-upload-input"' in html
 
 
-def test_run_demo_web_backtest_returns_summary_trades_and_assumptions() -> None:
+def test_run_demo_web_backtest_returns_summary_trades_assumptions_and_run_context() -> None:
     result = run_demo_web_backtest(
         form_data={
             "input_mode": "example",
@@ -31,6 +31,10 @@ def test_run_demo_web_backtest_returns_summary_trades_and_assumptions() -> None:
     assert "summary" in result.chart_sections
     assert any("印花税" in note for note in result.assumptions)
     assert result.sample_size_warning == SHORT_SAMPLE_WARNING
+    assert result.run_context is not None
+    assert result.run_context["input_mode"] == "example"
+    assert result.export_json is not None
+    assert result.equity_curve_points is not None
 
 
 def test_render_demo_page_shows_friendly_validation_error_for_invalid_ma_combo() -> None:
@@ -48,7 +52,7 @@ def test_render_demo_page_shows_friendly_validation_error_for_invalid_ma_combo()
     assert "短均线必须小于长均线" in html
 
 
-def test_render_demo_page_shows_short_sample_warning_when_metrics_are_degraded() -> None:
+def test_render_demo_page_shows_short_sample_warning_context_export_and_equity_curve() -> None:
     html = render_demo_page(
         form_data={
             "input_mode": "example",
@@ -60,6 +64,9 @@ def test_render_demo_page_shows_short_sample_warning_when_metrics_are_degraded()
     )
 
     assert 'data-testid="qb-sample-size-warning"' in html
+    assert 'data-testid="qb-run-context"' in html
+    assert 'data-testid="qb-export-json"' in html
+    assert 'data-testid="qb-equity-curve"' in html
     assert SHORT_SAMPLE_WARNING in html
 
 
@@ -118,3 +125,6 @@ def test_create_app_handles_health_and_demo_post_flow(tmp_path: Path) -> None:
     assert 'data-testid="qb-result-summary"' in html
     assert 'data-testid="qb-result-trades"' in html
     assert 'data-testid="qb-result-assumptions"' in html
+    assert 'data-testid="qb-run-context"' in html
+    assert 'data-testid="qb-export-json"' in html
+    assert 'data-testid="qb-equity-curve"' in html


### PR DESCRIPTION
## Summary

先交一个最小可用的结果页复盘增强版本：让 Web Demo 不再只剩静态 summary，而是能直接看到本次回测上下文、轻量权益曲线和结构化结果快照。

## Changes

- 在结果区新增本次回测上下文（input_mode / symbol / initial_cash / 均线参数 / bars_count / 数据区间）
- 新增 JSON 结果快照导出区，便于复制留痕与后续比较
- 新增轻量 SVG 权益曲线，补足最基本的时间维度解释能力
- 扩展 `DemoResultContext`，让页面层可直接消费 run context / export payload / equity curve points
- 更新页面与 demo 结果上下文测试

## Boundary

这次先做最小可交付版本，优先解决“结果难复盘”问题；
后续若继续扩展，可以再补：
- 真正的文件下载按钮
- drawdown 区间可视化
- benchmark 对比曲线
- 参数结果历史对比

## Testing

- `PYTHONPATH=src pytest -q`（73 passed）
- Web Demo / Demo context 相关测试已覆盖新增结果区块

Fixes zionwudt/quant-balance#51