### PR TITLE
fix: 为 demo 子模块补充入口迁移提示

### DIFF
--- a/src/quant_balance/demo.py
+++ b/src/quant_balance/demo.py
@@ -392,3 +392,19 @@ def parse_csv_text_to_bars(*, csv_text: str, symbol: str) -> list[MarketBar]:
         ) from exc
 
     return bars
+
+
+def _print_module_entry_hint() -> int:
+    import sys
+
+    print(
+        "quant_balance.demo 不是独立 CLI 入口。\n"
+        "请改用：python -m quant_balance demo --help\n"
+        "或：quant-balance demo --help",
+        file=sys.stderr,
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(_print_module_entry_hint())

--- a/src/quant_balance/web_demo.py
+++ b/src/quant_balance/web_demo.py
@@ -424,3 +424,19 @@ def _format_value(value: object) -> str:
     if isinstance(value, float):
         return f"{value:.2f}"
     return str(value)
+
+
+def _print_module_entry_hint() -> int:
+    import sys
+
+    print(
+        "quant_balance.web_demo 不是独立 CLI 入口。\n"
+        "请改用：python -m quant_balance web-demo --help\n"
+        "或：quant-balance web-demo --help",
+        file=sys.stderr,
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(_print_module_entry_hint())

--- a/tests/test_submodule_entrypoints.py
+++ b/tests/test_submodule_entrypoints.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_python_dash_m_quant_balance_demo_prints_migration_hint() -> None:
+    root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [sys.executable, "-m", "quant_balance.demo", "--help"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(root / 'src')},
+    )
+
+    assert result.returncode != 0
+    assert "请改用：python -m quant_balance demo --help" in result.stderr
+    assert "quant-balance demo --help" in result.stderr
+
+
+def test_python_dash_m_quant_balance_web_demo_prints_migration_hint() -> None:
+    root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [sys.executable, "-m", "quant_balance.web_demo", "--help"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(root / 'src')},
+    )
+
+    assert result.returncode != 0
+    assert "请改用：python -m quant_balance web-demo --help" in result.stderr
+    assert "quant-balance web-demo --help" in result.stderr


### PR DESCRIPTION
## Summary

避免用户直接执行 `python -m quant_balance.demo` / `python -m quant_balance.web_demo` 时静默退出，让首用路径至少能看到明确迁移提示。

## Changes

- 为 `quant_balance.demo` 增加模块直跑时的迁移提示
- 为 `quant_balance.web_demo` 增加模块直跑时的迁移提示
- 返回非 0 退出码，避免“看起来成功但什么都没发生”的假象
- 新增对应 smoke tests

## Testing

- `PYTHONPATH=src pytest -q`（77 passed）
- 子模块入口专项测试 2 passed

Fixes zionwudt/quant-balance#55