### PR TITLE
feat: 打通 demo 的 benchmark 对比链路

### DIFF
--- a/src/quant_balance/cli.py
+++ b/src/quant_balance/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+from dataclasses import replace
 import json
 import sys
 from pathlib import Path
@@ -13,6 +14,7 @@ from quant_balance.strategy import MovingAverageCrossStrategy
 from quant_balance.web_demo import DEFAULT_HOST, DEFAULT_PORT, run_demo_web_server
 
 DEFAULT_SYMBOL = "600519.SH"
+DEFAULT_BENCHMARK_NAME = "CSI300-demo"
 DEFAULT_EXAMPLE_PATH = Path(__file__).resolve().parents[2] / "examples" / "demo_backtest.csv"
 ROOT_COMMAND_HINT = "Use 'quant-balance --help' to explore commands, or try 'quant-balance demo' and 'quant-balance web-demo'."
 
@@ -87,6 +89,7 @@ def run_demo_backtest(
     initial_cash: float,
     short_window: int,
     long_window: int,
+    benchmark_name: str = DEFAULT_BENCHMARK_NAME,
 ) -> BacktestReport:
     if initial_cash <= 0:
         raise DemoValidationError("初始资金必须大于 0。")
@@ -106,6 +109,18 @@ def run_demo_backtest(
     result = engine.run(bars)
     if result.report is None:
         raise RuntimeError("backtest did not produce a report")
+
+    benchmark_equity_curve = _build_demo_benchmark_equity_curve(
+        initial_equity=initial_cash,
+        periods=len(result.equity_curve),
+    )
+    benchmark_return_pct = _safe_pct_change(benchmark_equity_curve[0], benchmark_equity_curve[-1]) if benchmark_equity_curve else None
+    result.report = replace(
+        result.report,
+        benchmark_name=benchmark_name,
+        benchmark_return_pct=benchmark_return_pct,
+        excess_return_pct=(result.report.total_return_pct - benchmark_return_pct) if benchmark_return_pct is not None else None,
+    )
     return result.report
 
 
@@ -140,3 +155,20 @@ def format_demo_summary(report: BacktestReport, *, csv_path: Path, symbol: str, 
     if report.max_drawdown_start and report.max_drawdown_end:
         lines.append(f"- Drawdown window: {report.max_drawdown_start.isoformat()} -> {report.max_drawdown_end.isoformat()}")
     return "\n".join(lines)
+
+
+def _build_demo_benchmark_equity_curve(*, initial_equity: float, periods: int) -> list[float]:
+    if periods <= 0:
+        return []
+    curve: list[float] = []
+    for index in range(periods):
+        progress = index / max(periods - 1, 1)
+        curve.append(initial_equity * (1 + 0.04 * progress))
+    return curve
+
+
+
+def _safe_pct_change(start: float, end: float) -> float:
+    if start <= 0:
+        return 0.0
+    return (end / start - 1.0) * 100

--- a/src/quant_balance/web_demo.py
+++ b/src/quant_balance/web_demo.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from email.parser import BytesParser
 from email.policy import default as email_policy
+from dataclasses import replace
 from html import escape
 from pathlib import Path
 from typing import Callable
@@ -16,6 +17,7 @@ from quant_balance.strategy import MovingAverageCrossStrategy
 
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8765
+DEFAULT_BENCHMARK_NAME = "CSI300-demo"
 DEFAULT_EXAMPLE_CSV_PATH = Path(__file__).resolve().parents[2] / "examples" / "demo_backtest.csv"
 
 WSGIApp = Callable[[dict[str, object], Callable[[str, list[tuple[str, str]]], None]], list[bytes]]
@@ -259,6 +261,18 @@ def run_demo_web_backtest(
     result = engine.run(bars)
     if result.report is None:
         raise RuntimeError("回测未生成 report")
+
+    benchmark_equity_curve = _build_demo_benchmark_equity_curve(
+        initial_equity=initial_cash,
+        periods=len(result.equity_curve),
+    )
+    benchmark_return_pct = _safe_pct_change(benchmark_equity_curve[0], benchmark_equity_curve[-1]) if benchmark_equity_curve else None
+    result.report = replace(
+        result.report,
+        benchmark_name=DEFAULT_BENCHMARK_NAME,
+        benchmark_return_pct=benchmark_return_pct,
+        excess_return_pct=(result.report.total_return_pct - benchmark_return_pct) if benchmark_return_pct is not None else None,
+    )
     return build_demo_result_context(result.report)
 
 
@@ -424,3 +438,20 @@ def _format_value(value: object) -> str:
     if isinstance(value, float):
         return f"{value:.2f}"
     return str(value)
+
+
+def _build_demo_benchmark_equity_curve(*, initial_equity: float, periods: int) -> list[float]:
+    if periods <= 0:
+        return []
+    curve: list[float] = []
+    for index in range(periods):
+        progress = index / max(periods - 1, 1)
+        curve.append(initial_equity * (1 + 0.04 * progress))
+    return curve
+
+
+
+def _safe_pct_change(start: float, end: float) -> float:
+    if start <= 0:
+        return 0.0
+    return (end / start - 1.0) * 100

--- a/tests/test_cli_demo.py
+++ b/tests/test_cli_demo.py
@@ -57,3 +57,6 @@ def test_module_demo_command_supports_json_output() -> None:
     assert payload["trades_count"] >= 1
     assert payload["max_drawdown_start"] is not None
     assert payload["sample_size_warning"] is not None
+    assert payload["benchmark_name"] == "CSI300-demo"
+    assert payload["benchmark_return_pct"] is not None
+    assert payload["excess_return_pct"] is not None

--- a/tests/test_web_demo.py
+++ b/tests/test_web_demo.py
@@ -31,6 +31,9 @@ def test_run_demo_web_backtest_returns_summary_trades_and_assumptions() -> None:
     assert "summary" in result.chart_sections
     assert any("印花税" in note for note in result.assumptions)
     assert result.sample_size_warning == SHORT_SAMPLE_WARNING
+    assert result.summary["benchmark_name"] == "CSI300-demo"
+    assert result.summary["benchmark_return_pct"] is not None
+    assert result.summary["excess_return_pct"] is not None
 
 
 def test_render_demo_page_shows_friendly_validation_error_for_invalid_ma_combo() -> None:


### PR DESCRIPTION
## Summary

先打通一个最小可用的 benchmark 对比链路，让 demo CLI / Web Demo 主路径不再把 benchmark / excess return 长期展示成占位字段。

## Changes

- 为 demo CLI 接入一个内置 benchmark 示例曲线（`CSI300-demo`）
- 为 Web Demo 结果页同步补齐 benchmark_name / benchmark_return_pct / excess_return_pct
- 保持实现最小化：先用内置 benchmark 跑通主链路，后续再扩展自定义 benchmark 输入
- 补充 CLI / Web Demo 对应回归测试

## Boundary

这次先做阶段 1 的最小可交付版本：
- benchmark 来源先内置，不新增用户输入复杂度
- 先解决“字段长期空值”的产品断层
- 后续可以继续扩展 benchmark 上传/选择与同图对比

## Testing

- `PYTHONPATH=src pytest -q`（75 passed）
- CLI / Web Demo benchmark 断言已覆盖

Fixes zionwudt/quant-balance#56