### PR TITLE
docs: 更新 Web Demo 上传路径说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,10 +207,12 @@ Then open <http://127.0.0.1:8765/demo> in your browser.
 Current MVP capabilities:
 
 - single-page form with stable `data-testid` anchors for future browser automation
-- choose example data or paste uploaded CSV content into the page
+- choose example data or upload a real local CSV file from the page
+- keep a textarea-based CSV path only as a developer/debug fallback, not the primary user flow
 - submit a backtest and view summary / closed trades / assumptions in one page
 - surface the existing Chinese validation errors directly in the page
 
 Current boundary:
 
-- the "upload CSV" flow is temporarily implemented as textarea paste input, so the browser path is already testable before a real multipart upload widget is introduced
+- benchmark input is still fixed to the current built-in demo path; custom benchmark upload/selection is not exposed yet
+- result visualization is still a lightweight local-demo shell, not a full charting/report workspace

--- a/tests/test_readme_web_demo_docs.py
+++ b/tests/test_readme_web_demo_docs.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_readme_web_demo_copy_matches_real_file_upload_flow() -> None:
+    root = Path(__file__).resolve().parents[1]
+    readme = (root / "README.md").read_text(encoding="utf-8")
+
+    assert "upload a real local CSV file" in readme
+    assert "textarea-based CSV path only as a developer/debug fallback" in readme
+    assert 'the "upload CSV" flow is temporarily implemented as textarea paste input' not in readme
+    assert "paste uploaded CSV content into the page" not in readme


### PR DESCRIPTION
## Summary

把 README / onboarding 中关于 Web Demo 上传路径的描述更新到当前真实实现，避免新用户继续被“textarea 占位上传”这类过期文案误导。

## Changes

- README 改为明确描述真实本地 CSV 文件上传能力
- 明确 textarea 仅作为开发/调试辅助路径保留
- 将边界说明更新为当前真实未支持项，而不是继续描述已经失效的旧实现
- 新增 README 文案回归测试，防止后续再次漂移

## Testing

- `PYTHONPATH=src pytest -q`（78 passed）
- README 文案专项测试 1 passed

Fixes zionwudt/quant-balance#59