### PR TITLE
fix: 对齐 Web Demo 示例数据与内置示例文件

### DIFF
--- a/src/quant_balance/demo.py
+++ b/src/quant_balance/demo.py
@@ -5,6 +5,7 @@ from datetime import date
 import csv
 import io
 import json
+from pathlib import Path
 
 from quant_balance.models import MarketBar
 from quant_balance.report import BacktestReport
@@ -146,15 +147,8 @@ def get_csv_template() -> str:
 
 
 def get_example_csv() -> str:
-    return "\n".join(
-        [
-            ",".join(REQUIRED_CSV_COLUMNS),
-            "2026-01-05,10.00,10.30,9.90,10.20,1250000",
-            "2026-01-06,10.25,10.50,10.10,10.45,1320000",
-            "2026-01-07,10.50,10.80,10.40,10.75,1180000",
-            "2026-01-08,10.70,10.90,10.55,10.60,980000",
-        ]
-    )
+    example_path = Path(__file__).resolve().parents[2] / "examples" / "demo_backtest.csv"
+    return example_path.read_text(encoding="utf-8")
 
 
 def build_demo_page_context(*, developer_mode: bool = False) -> DemoPageContext:

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -68,8 +68,9 @@ def test_parse_csv_text_to_bars_accepts_headers_with_spaces() -> None:
 def test_load_demo_bars_supports_example_mode() -> None:
     bars = load_demo_bars(BacktestDemoRequest(input_mode="example", symbol="600519.SH"))
 
-    assert len(bars) == 4
+    assert len(bars) == 18
     assert bars[0].symbol == "600519.SH"
+    assert bars[-1].date.isoformat() == "2026-01-28"
 
 
 def test_load_demo_bars_returns_friendly_file_not_found_message() -> None:

--- a/tests/test_example_data_consistency.py
+++ b/tests/test_example_data_consistency.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from quant_balance.cli import DEFAULT_EXAMPLE_PATH, run_demo_backtest
+from quant_balance.web_demo import run_demo_web_backtest
+
+
+
+def test_web_example_mode_matches_cli_builtin_example_dataset() -> None:
+    cli_report = run_demo_backtest(
+        csv_path=DEFAULT_EXAMPLE_PATH,
+        symbol="600519.SH",
+        initial_cash=100_000.0,
+        short_window=5,
+        long_window=20,
+    )
+    web_result = run_demo_web_backtest(
+        form_data={
+            "input_mode": "example",
+            "symbol": "600519.SH",
+            "initial_cash": "100000",
+            "short_window": "5",
+            "long_window": "20",
+        }
+    )
+
+    assert web_result.run_context is not None
+    assert web_result.run_context["bars_count"] == 18
+    assert web_result.run_context["date_range_end"] == "2026-01-28"
+    assert web_result.summary["final_equity"] == cli_report.final_equity
+    assert web_result.summary["trades_count"] == cli_report.trades_count
+    assert web_result.summary["max_drawdown_end"] == cli_report.max_drawdown_end.isoformat()

--- a/tests/test_web_demo.py
+++ b/tests/test_web_demo.py
@@ -33,6 +33,8 @@ def test_run_demo_web_backtest_returns_summary_trades_assumptions_and_run_contex
     assert result.sample_size_warning == SHORT_SAMPLE_WARNING
     assert result.run_context is not None
     assert result.run_context["input_mode"] == "example"
+    assert result.run_context["bars_count"] == 18
+    assert result.run_context["date_range_end"] == "2026-01-28"
     assert result.export_json is not None
     assert result.equity_curve_points is not None
 


### PR DESCRIPTION
## Summary

修复 Web Demo `example` 模式与 CLI / 上传同文件结果不一致的问题，让示例数据主路径真正对齐仓库内置示例文件 `examples/demo_backtest.csv`。

## Changes

- 让 `demo.get_example_csv()` 改为读取真实的 `examples/demo_backtest.csv`
- 消除 Web example 模式仍停留在 4 根内嵌 bar 的旧行为
- 新增 CLI / Web example 一致性回归测试
- 更新旧测试口径到真实示例文件长度与日期范围

## Testing

- `PYTHONPATH=src pytest -q`（81 passed）
- 新增 example consistency 专项测试

Fixes zionwudt/quant-balance#63